### PR TITLE
Export dependency on ament_cmake_google_benchmark

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ set(BUILD_SHARED_LIBS TRUE CACHE BOOL "Build shared libraries")
 
 # find dependencies
 find_package(ament_cmake_core REQUIRED)
+find_package(ament_cmake_export_dependencies REQUIRED)
 find_package(ament_cmake_export_targets REQUIRED)
 find_package(benchmark REQUIRED)
 find_package(osrf_testing_tools_cpp REQUIRED)
@@ -47,6 +48,7 @@ install(
   DESTINATION share/${PROJECT_NAME})
 
 ament_export_targets(${PROJECT_NAME})
+ament_export_dependencies(ament_cmake_google_benchmark)
 
 ament_package(
   CONFIG_EXTRAS_POST "${PROJECT_NAME}-extras.cmake"

--- a/package.xml
+++ b/package.xml
@@ -10,6 +10,7 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_core</buildtool_depend>
+  <buildtool_depend>ament_cmake_export_dependencies</buildtool_depend>
   <buildtool_depend>ament_cmake_export_targets</buildtool_depend>
 
   <buildtool_export_depend>ament_cmake_google_benchmark</buildtool_export_depend>


### PR DESCRIPTION
Since the *-extras.cmake for this package calls macros defined in ament_cmake_google_benchmark, it must be find_package()'d before this package. The simplest way to ensure that happens is to export the ament dependency.