### PR TITLE
Suppress memory tools warning if tests will be skipped

### DIFF
--- a/performance_test_fixture-extras.cmake
+++ b/performance_test_fixture-extras.cmake
@@ -21,7 +21,7 @@ macro(_performance_test_fixture_find_memory_tools)
       osrf_testing_tools_cpp::memory_tools LIBRARY_PRELOAD_ENVIRONMENT_IS_AVAILABLE)
 
     if(NOT _PERFORMANCE_TEST_FIXTURE_MEMORY_TOOLS_AVAILABLE)
-      if(NOT AMENT_RUN_PERFORMANCE_TESTS)
+      if(AMENT_RUN_PERFORMANCE_TESTS)
         message(WARNING
           "'osrf_testing_tools_cpp' memory tools are not available, C++ tests "
           "using 'performance_test_fixture' can not be run and will be skipped.")

--- a/performance_test_fixture-extras.cmake
+++ b/performance_test_fixture-extras.cmake
@@ -21,9 +21,11 @@ macro(_performance_test_fixture_find_memory_tools)
       osrf_testing_tools_cpp::memory_tools LIBRARY_PRELOAD_ENVIRONMENT_IS_AVAILABLE)
 
     if(NOT _PERFORMANCE_TEST_FIXTURE_MEMORY_TOOLS_AVAILABLE)
-      message(WARNING
-        "'osrf_testing_tools_cpp' memory tools are not available, C++ tests "
-        "using 'performance_test_fixture' can not be run and will be skipped.")
+      if(NOT AMENT_RUN_PERFORMANCE_TESTS)
+        message(WARNING
+          "'osrf_testing_tools_cpp' memory tools are not available, C++ tests "
+          "using 'performance_test_fixture' can not be run and will be skipped.")
+      endif()
     else()
       get_target_property(_PERFORMANCE_TEST_FIXTURE_MEMORY_TOOLS_ENV
         osrf_testing_tools_cpp::memory_tools LIBRARY_PRELOAD_ENVIRONMENT_VARIABLE)


### PR DESCRIPTION
I'd prefer to inspect the test itself to see if it will be skipped individually, but this warning is implemented in a common location so that it is printed once, instead of once for each defined test. Looking at the source variable, `AMENT_RUN_PERFORMANCE_TESTS`, should give us the same behavior.

Coupled to ament/ament_cmake#278.