### PR TITLE
Stop recording memory operations sooner

### DIFF
--- a/src/performance_test_fixture.cpp
+++ b/src/performance_test_fixture.cpp
@@ -69,6 +69,9 @@ void performance_test_fixture::PerformanceTest::SetUp(benchmark::State &)
 
 void performance_test_fixture::PerformanceTest::TearDown(benchmark::State & state)
 {
+  osrf_testing_tools_cpp::memory_tools::expect_no_malloc_end();
+  osrf_testing_tools_cpp::memory_tools::expect_no_realloc_end();
+
   if (osrf_testing_tools_cpp::memory_tools::is_working()) {
     state.counters["heap_allocations"] = benchmark::Counter(
       static_cast<double>(allocation_count),


### PR DESCRIPTION
It looks like the process of recording the number of allocations involves performing allocations itself, which we're obviously not interested in including in the statistics.