### PR TITLE
Expose a function for resetting the heap counters

### DIFF
--- a/include/performance_test_fixture/performance_test_fixture.hpp
+++ b/include/performance_test_fixture/performance_test_fixture.hpp
@@ -42,6 +42,9 @@ protected:
   PERFORMANCE_TEST_FIXTURE_PUBLIC
   void on_realloc(osrf_testing_tools_cpp::memory_tools::MemoryToolsService & service);
 
+  PERFORMANCE_TEST_FIXTURE_PUBLIC
+  void reset_heap_counters();
+
 private:
   size_t allocation_count;
   bool suppress_memory_tools_logging;

--- a/src/performance_test_fixture.cpp
+++ b/src/performance_test_fixture.cpp
@@ -47,7 +47,7 @@ performance_test_fixture::PerformanceTest::PerformanceTest()
 
 void performance_test_fixture::PerformanceTest::SetUp(benchmark::State &)
 {
-  allocation_count = 0;
+  reset_heap_counters();
 
   osrf_testing_tools_cpp::memory_tools::initialize();
   osrf_testing_tools_cpp::memory_tools::on_unexpected_malloc(
@@ -100,4 +100,9 @@ void performance_test_fixture::PerformanceTest::on_realloc(
   if (suppress_memory_tools_logging) {
     service.ignore();
   }
+}
+
+void performance_test_fixture::PerformanceTest::reset_heap_counters()
+{
+  allocation_count = 0;
 }


### PR DESCRIPTION
This can be used to ignore heap allocations that were performed during the test setup, and therefore aren't relevant to the function under test.