### PR TITLE
Export dependency on benchmark and osrf_testing_tools_cpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@ install(
   DESTINATION share/${PROJECT_NAME})
 
 ament_export_targets(${PROJECT_NAME})
-ament_export_dependencies(ament_cmake_google_benchmark)
+ament_export_dependencies(ament_cmake_google_benchmark benchmark osrf_testing_tools_cpp)
 
 ament_package(
   CONFIG_EXTRAS_POST "${PROJECT_NAME}-extras.cmake"


### PR DESCRIPTION
This should ensure that those targets are imported and available to link against when the macros are invoked.

We've been getting away with this when invoking `add_performance_test` from the root scope of a project, because these packages are `find_package()`'d as part of the `-extras.cmake` processing of `performance_test_fixture` and `ament_cmake_google_benchmark`. However, when we invoke `add_performance_test` from another scope, we need to ensure that they are explicitly available.

I can't explain why explicitly `find_package()`-ing these targets from the other scopes didn't work around the problem, but this seems to resolve the issue.