### PR TITLE
Use namespace performance_test_fixture for shorter method names in .cpp

### DIFF
--- a/src/performance_test_fixture.cpp
+++ b/src/performance_test_fixture.cpp
@@ -22,7 +22,10 @@
 #pragma warning(disable : 4996)
 #endif
 
-performance_test_fixture::PerformanceTest::PerformanceTest()
+namespace performance_test_fixture
+{
+
+PerformanceTest::PerformanceTest()
 : suppress_memory_tools_logging(true)
 {
   const char * performance_test_fixture_enable_trace = getenv(
@@ -45,29 +48,23 @@ performance_test_fixture::PerformanceTest::PerformanceTest()
     });
 }
 
-void performance_test_fixture::PerformanceTest::SetUp(benchmark::State &)
+void PerformanceTest::SetUp(benchmark::State &)
 {
   reset_heap_counters();
 
   osrf_testing_tools_cpp::memory_tools::initialize();
   osrf_testing_tools_cpp::memory_tools::on_unexpected_malloc(
     std::function<void(osrf_testing_tools_cpp::memory_tools::MemoryToolsService &)>(
-      std::bind(
-        &performance_test_fixture::PerformanceTest::on_malloc,
-        this,
-        std::placeholders::_1)));
+      std::bind(&PerformanceTest::on_malloc, this, std::placeholders::_1)));
   osrf_testing_tools_cpp::memory_tools::on_unexpected_realloc(
     std::function<void(osrf_testing_tools_cpp::memory_tools::MemoryToolsService &)>(
-      std::bind(
-        &performance_test_fixture::PerformanceTest::on_realloc,
-        this,
-        std::placeholders::_1)));
+      std::bind(&PerformanceTest::on_realloc, this, std::placeholders::_1)));
   osrf_testing_tools_cpp::memory_tools::enable_monitoring();
   osrf_testing_tools_cpp::memory_tools::expect_no_malloc_begin();
   osrf_testing_tools_cpp::memory_tools::expect_no_realloc_begin();
 }
 
-void performance_test_fixture::PerformanceTest::TearDown(benchmark::State & state)
+void PerformanceTest::TearDown(benchmark::State & state)
 {
   osrf_testing_tools_cpp::memory_tools::expect_no_malloc_end();
   osrf_testing_tools_cpp::memory_tools::expect_no_realloc_end();
@@ -82,7 +79,7 @@ void performance_test_fixture::PerformanceTest::TearDown(benchmark::State & stat
   osrf_testing_tools_cpp::memory_tools::uninitialize();
 }
 
-void performance_test_fixture::PerformanceTest::on_malloc(
+void PerformanceTest::on_malloc(
   osrf_testing_tools_cpp::memory_tools::MemoryToolsService & service
 )
 {
@@ -92,7 +89,7 @@ void performance_test_fixture::PerformanceTest::on_malloc(
   }
 }
 
-void performance_test_fixture::PerformanceTest::on_realloc(
+void PerformanceTest::on_realloc(
   osrf_testing_tools_cpp::memory_tools::MemoryToolsService & service
 )
 {
@@ -102,7 +99,9 @@ void performance_test_fixture::PerformanceTest::on_realloc(
   }
 }
 
-void performance_test_fixture::PerformanceTest::reset_heap_counters()
+void PerformanceTest::reset_heap_counters()
 {
   allocation_count = 0;
 }
+
+}  // namespace performance_test_fixture


### PR DESCRIPTION
Small commit to cleanup these method names as they get a bit long, especially with parameters.
Signed-off-by: Stephen Brawner <brawner@gmail.com>