### PR TITLE
Add methods for pausing/resuming performance metrics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,8 +65,6 @@ if(BUILD_TESTING)
     test/benchmark/benchmark_malloc_realloc.cpp
     TIMEOUT 60)
 
-  # Adding executable and linking done manually to avoid dependency on
-  # osrf_testing_tools_cpp
   # Bypassing performance_test_fixture to avoid LD_PRELOAD of
   # osrf_testing_tools_cpp
   set(_no_mem_tools_skip_arg)
@@ -82,6 +80,10 @@ if(BUILD_TESTING)
     benchmark_malloc_realloc_no_memory_tools
     test/benchmark/benchmark_malloc_realloc_no_memory_tools.cpp
     ${_no_mem_tools_skip_arg})
+
+  add_performance_test(
+    benchmark_pause_resume
+    test/benchmark/benchmark_pause_resume.cpp)
 endif()
 
 ament_package(

--- a/include/performance_test_fixture/performance_test_fixture.hpp
+++ b/include/performance_test_fixture/performance_test_fixture.hpp
@@ -45,9 +45,16 @@ protected:
   PERFORMANCE_TEST_FIXTURE_PUBLIC
   void reset_heap_counters();
 
+  PERFORMANCE_TEST_FIXTURE_PUBLIC
+  void pause_performance_measurements(::benchmark::State & state);
+
+  PERFORMANCE_TEST_FIXTURE_PUBLIC
+  void resume_performance_measurements(::benchmark::State & state);
+
 private:
   size_t allocation_count;
   bool suppress_memory_tools_logging;
+  bool are_performance_measurements_paused;
 };
 
 }  // namespace performance_test_fixture

--- a/include/performance_test_fixture/performance_test_fixture.hpp
+++ b/include/performance_test_fixture/performance_test_fixture.hpp
@@ -46,17 +46,33 @@ protected:
   void reset_heap_counters();
 
   PERFORMANCE_TEST_FIXTURE_PUBLIC
-  void pause_performance_measurements(::benchmark::State & state);
-
-  PERFORMANCE_TEST_FIXTURE_PUBLIC
-  void resume_performance_measurements(::benchmark::State & state);
+  void set_are_allocation_measurements_active(bool value);
 
 private:
   size_t allocation_count;
   bool suppress_memory_tools_logging;
-  bool are_performance_measurements_active;
+  bool are_allocation_measurements_active;
 };
 
 }  // namespace performance_test_fixture
+
+/**
+ * Macro to pause timing and heap allocation measurements over a section of code.
+ *
+ * This is useful if there is setup or teardown that has to occur with every iteration.
+ * For example, if you wanted to measure only construction of a rclcpp::Node and not its
+ * destruction.
+ *
+ * state.PauseTiming() does not allocate, so it should go first to minimize discrepencies in
+ * measuring timing
+ */
+#define PERFORMANCE_TEST_FIXTURE_PAUSE_MEASUREMENTS(state, code) \
+  do { \
+    state.PauseTiming(); \
+    set_are_allocation_measurements_active(false); \
+    code; \
+    set_are_allocation_measurements_active(true); \
+    state.ResumeTiming(); \
+  } while (0)
 
 #endif  // PERFORMANCE_TEST_FIXTURE__PERFORMANCE_TEST_FIXTURE_HPP_

--- a/include/performance_test_fixture/performance_test_fixture.hpp
+++ b/include/performance_test_fixture/performance_test_fixture.hpp
@@ -54,7 +54,7 @@ protected:
 private:
   size_t allocation_count;
   bool suppress_memory_tools_logging;
-  bool are_performance_measurements_paused;
+  bool are_performance_measurements_active;
 };
 
 }  // namespace performance_test_fixture

--- a/src/performance_test_fixture.cpp
+++ b/src/performance_test_fixture.cpp
@@ -26,7 +26,7 @@ namespace performance_test_fixture
 {
 
 PerformanceTest::PerformanceTest()
-: suppress_memory_tools_logging(true), are_performance_measurements_active(false)
+: suppress_memory_tools_logging(true), are_allocation_measurements_active(false)
 {
   const char * performance_test_fixture_enable_trace = getenv(
     "PERFORMANCE_TEST_FIXTURE_ENABLE_TRACE");
@@ -84,7 +84,7 @@ void PerformanceTest::on_malloc(
 )
 {
   // Refraining from using an if-branch here in performance-critical code
-  allocation_count += static_cast<size_t>(are_performance_measurements_active);
+  allocation_count += static_cast<size_t>(are_allocation_measurements_active);
 
   if (suppress_memory_tools_logging) {
     service.ignore();
@@ -96,7 +96,7 @@ void PerformanceTest::on_realloc(
 )
 {
   // Refraining from using an if-branch here in performance-critical code
-  allocation_count += static_cast<size_t>(are_performance_measurements_active);
+  allocation_count += static_cast<size_t>(are_allocation_measurements_active);
 
   if (suppress_memory_tools_logging) {
     service.ignore();
@@ -106,19 +106,13 @@ void PerformanceTest::on_realloc(
 void PerformanceTest::reset_heap_counters()
 {
   allocation_count = 0;
-  are_performance_measurements_active = true;
+  are_allocation_measurements_active = true;
 }
 
-void PerformanceTest::pause_performance_measurements(::benchmark::State & state)
+void PerformanceTest::set_are_allocation_measurements_active(bool value)
 {
-  state.PauseTiming();
-  are_performance_measurements_active = false;
+  are_allocation_measurements_active = value;
 }
 
-void PerformanceTest::resume_performance_measurements(::benchmark::State & state)
-{
-  are_performance_measurements_active = true;
-  state.ResumeTiming();
-}
 
 }  // namespace performance_test_fixture

--- a/src/performance_test_fixture.cpp
+++ b/src/performance_test_fixture.cpp
@@ -26,7 +26,7 @@ namespace performance_test_fixture
 {
 
 PerformanceTest::PerformanceTest()
-: suppress_memory_tools_logging(true), are_performance_measurements_paused(true)
+: suppress_memory_tools_logging(true), are_performance_measurements_active(false)
 {
   const char * performance_test_fixture_enable_trace = getenv(
     "PERFORMANCE_TEST_FIXTURE_ENABLE_TRACE");
@@ -84,7 +84,7 @@ void PerformanceTest::on_malloc(
 )
 {
   // Refraining from using an if-branch here in performance-critical code
-  allocation_count += static_cast<size_t>(are_performance_measurements_paused);
+  allocation_count += static_cast<size_t>(are_performance_measurements_active);
 
   if (suppress_memory_tools_logging) {
     service.ignore();
@@ -96,7 +96,7 @@ void PerformanceTest::on_realloc(
 )
 {
   // Refraining from using an if-branch here in performance-critical code
-  allocation_count += static_cast<size_t>(are_performance_measurements_paused);
+  allocation_count += static_cast<size_t>(are_performance_measurements_active);
 
   if (suppress_memory_tools_logging) {
     service.ignore();
@@ -106,18 +106,18 @@ void PerformanceTest::on_realloc(
 void PerformanceTest::reset_heap_counters()
 {
   allocation_count = 0;
-  are_performance_measurements_paused = false;
+  are_performance_measurements_active = true;
 }
 
 void PerformanceTest::pause_performance_measurements(::benchmark::State & state)
 {
   state.PauseTiming();
-  are_performance_measurements_paused = true;
+  are_performance_measurements_active = false;
 }
 
 void PerformanceTest::resume_performance_measurements(::benchmark::State & state)
 {
-  are_performance_measurements_paused = false;
+  are_performance_measurements_active = true;
   state.ResumeTiming();
 }
 

--- a/test/benchmark/benchmark_pause_resume.cpp
+++ b/test/benchmark/benchmark_pause_resume.cpp
@@ -1,0 +1,92 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cstdlib>
+#include <string>
+
+#include "./macros.h"
+#include "performance_test_fixture/performance_test_fixture.hpp"
+
+namespace
+{
+
+constexpr int kEnablePerformanceTracking = 1;
+constexpr int kDisablePerformanceTracking = 0;
+
+}  // namespace
+
+class PerformanceTestFixture : public performance_test_fixture::PerformanceTest
+{
+public:
+  void SetUp(benchmark::State & state)
+  {
+    if (kEnablePerformanceTracking != state.range(0) &&
+      kDisablePerformanceTracking != state.range(0))
+    {
+      std::string message =
+        std::string("Invalid enable/disable value: ") + std::to_string(state.range(0));
+      state.SkipWithError(message.c_str());
+    }
+    if (kEnablePerformanceTracking == state.range(0)) {
+      performance_test_fixture::PerformanceTest::SetUp(state);
+    }
+  }
+
+  void TearDown(benchmark::State & state)
+  {
+    if (kEnablePerformanceTracking == state.range(0)) {
+      performance_test_fixture::PerformanceTest::TearDown(state);
+    }
+  }
+};
+
+BENCHMARK_DEFINE_F(PerformanceTestFixture, benchmark_pause_resume_timing)(
+  benchmark::State & state)
+{
+  for (auto _ : state) {
+    auto start = std::chrono::steady_clock::now();
+    state.PauseTiming();
+    state.ResumeTiming();
+    auto duration =
+      std::chrono::duration_cast<std::chrono::duration<double>>(
+      std::chrono::steady_clock::now() - start);
+    state.SetIterationTime(duration.count());
+  }
+}
+
+BENCHMARK_DEFINE_F(PerformanceTestFixture, benchmark_pause_resume_measurements)(
+  benchmark::State & state)
+{
+  for (auto _ : state) {
+    auto start = std::chrono::steady_clock::now();
+    PERFORMANCE_TEST_FIXTURE_PAUSE_MEASUREMENTS(state, {});
+    auto duration =
+      std::chrono::duration_cast<std::chrono::duration<double>>(
+      std::chrono::steady_clock::now() - start);
+    state.SetIterationTime(duration.count());
+  }
+}
+
+BENCHMARK_REGISTER_F(PerformanceTestFixture, benchmark_pause_resume_timing)
+->UseManualTime()
+->ArgNames({"Enable Performance Tracking"})
+->Arg(kEnablePerformanceTracking)
+->Arg(kDisablePerformanceTracking);
+
+BENCHMARK_REGISTER_F(PerformanceTestFixture, benchmark_pause_resume_measurements)
+->UseManualTime()
+->ArgNames({"Enable Performance Tracking"})
+->Arg(kEnablePerformanceTracking);
+
+BENCHMARK_MAIN();

--- a/test/benchmark/benchmark_pause_resume.cpp
+++ b/test/benchmark/benchmark_pause_resume.cpp
@@ -69,6 +69,7 @@ BENCHMARK_DEFINE_F(PerformanceTestFixture, benchmark_pause_resume_measurements)(
   benchmark::State & state)
 {
   for (auto _ : state) {
+    // Manual timing is used here because state.PauseTiming() is called from within.
     auto start = std::chrono::steady_clock::now();
     PERFORMANCE_TEST_FIXTURE_PAUSE_MEASUREMENTS(state, {});
     auto duration =


### PR DESCRIPTION
Here is my take on some basic pause/resume functions for pausing timing and heap allocation measurements. I'll open an example soon over at rclcpp for demonstration.

Signed-off-by: Stephen Brawner <brawner@gmail.com>