### PR TITLE
Record calls to calloc, update tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,7 @@ if(BUILD_TESTING)
   add_performance_test(
     benchmark_malloc_realloc
     test/benchmark/benchmark_malloc_realloc.cpp
-    TIMEOUT 60)
+    TIMEOUT 90)
 
   # Bypassing performance_test_fixture to avoid LD_PRELOAD of
   # osrf_testing_tools_cpp
@@ -79,7 +79,8 @@ if(BUILD_TESTING)
   ament_add_google_benchmark(
     benchmark_malloc_realloc_no_memory_tools
     test/benchmark/benchmark_malloc_realloc_no_memory_tools.cpp
-    ${_no_mem_tools_skip_arg})
+    ${_no_mem_tools_skip_arg}
+    TIMEOUT 60)
 
   add_performance_test(
     benchmark_pause_resume

--- a/include/performance_test_fixture/performance_test_fixture.hpp
+++ b/include/performance_test_fixture/performance_test_fixture.hpp
@@ -39,10 +39,7 @@ public:
 
 protected:
   PERFORMANCE_TEST_FIXTURE_PUBLIC
-  void on_malloc(osrf_testing_tools_cpp::memory_tools::MemoryToolsService & service);
-
-  PERFORMANCE_TEST_FIXTURE_PUBLIC
-  void on_realloc(osrf_testing_tools_cpp::memory_tools::MemoryToolsService & service);
+  void on_alloc(osrf_testing_tools_cpp::memory_tools::MemoryToolsService & service);
 
   PERFORMANCE_TEST_FIXTURE_PUBLIC
   void reset_heap_counters();

--- a/src/performance_test_fixture.cpp
+++ b/src/performance_test_fixture.cpp
@@ -53,19 +53,24 @@ void PerformanceTest::SetUp(benchmark::State &)
   reset_heap_counters();
 
   osrf_testing_tools_cpp::memory_tools::initialize();
+  osrf_testing_tools_cpp::memory_tools::on_unexpected_calloc(
+    std::function<void(osrf_testing_tools_cpp::memory_tools::MemoryToolsService &)>(
+      std::bind(&PerformanceTest::on_alloc, this, std::placeholders::_1)));
   osrf_testing_tools_cpp::memory_tools::on_unexpected_malloc(
     std::function<void(osrf_testing_tools_cpp::memory_tools::MemoryToolsService &)>(
-      std::bind(&PerformanceTest::on_malloc, this, std::placeholders::_1)));
+      std::bind(&PerformanceTest::on_alloc, this, std::placeholders::_1)));
   osrf_testing_tools_cpp::memory_tools::on_unexpected_realloc(
     std::function<void(osrf_testing_tools_cpp::memory_tools::MemoryToolsService &)>(
-      std::bind(&PerformanceTest::on_realloc, this, std::placeholders::_1)));
+      std::bind(&PerformanceTest::on_alloc, this, std::placeholders::_1)));
   osrf_testing_tools_cpp::memory_tools::enable_monitoring();
+  osrf_testing_tools_cpp::memory_tools::expect_no_calloc_begin();
   osrf_testing_tools_cpp::memory_tools::expect_no_malloc_begin();
   osrf_testing_tools_cpp::memory_tools::expect_no_realloc_begin();
 }
 
 void PerformanceTest::TearDown(benchmark::State & state)
 {
+  osrf_testing_tools_cpp::memory_tools::expect_no_calloc_end();
   osrf_testing_tools_cpp::memory_tools::expect_no_malloc_end();
   osrf_testing_tools_cpp::memory_tools::expect_no_realloc_end();
 
@@ -79,19 +84,7 @@ void PerformanceTest::TearDown(benchmark::State & state)
   osrf_testing_tools_cpp::memory_tools::uninitialize();
 }
 
-void PerformanceTest::on_malloc(
-  osrf_testing_tools_cpp::memory_tools::MemoryToolsService & service
-)
-{
-  // Refraining from using an if-branch here in performance-critical code
-  allocation_count += static_cast<size_t>(are_allocation_measurements_active);
-
-  if (suppress_memory_tools_logging) {
-    service.ignore();
-  }
-}
-
-void PerformanceTest::on_realloc(
+void PerformanceTest::on_alloc(
   osrf_testing_tools_cpp::memory_tools::MemoryToolsService & service
 )
 {

--- a/test/benchmark/benchmark_malloc_realloc.cpp
+++ b/test/benchmark/benchmark_malloc_realloc.cpp
@@ -57,14 +57,32 @@ public:
 BENCHMARK_DEFINE_F(PerformanceTestFixture, benchmark_on_malloc)(
   benchmark::State & state)
 {
-  const size_t malloc_size = state.range(1);
-  if (malloc_size < 1) {
+  const size_t alloc_size = state.range(1);
+  if (alloc_size < 1) {
     state.SkipWithError("Size for allocation is too small for this test");
   }
   for (auto _ : state) {
-    void * ptr = std::malloc(malloc_size);
+    void * ptr = std::malloc(alloc_size);
     if (PERFORMANCE_TEST_FIXTURE_UNLIKELY(nullptr == ptr)) {
       state.SkipWithError("Malloc failed to malloc");
+    }
+    std::free(ptr);
+    benchmark::DoNotOptimize(ptr);
+    benchmark::ClobberMemory();
+  }
+}
+
+BENCHMARK_DEFINE_F(PerformanceTestFixture, benchmark_on_calloc)(
+  benchmark::State & state)
+{
+  const size_t alloc_size = state.range(1);
+  if (alloc_size < 1) {
+    state.SkipWithError("Size for allocation is too small for this test");
+  }
+  for (auto _ : state) {
+    void * ptr = std::calloc(1, alloc_size);
+    if (PERFORMANCE_TEST_FIXTURE_UNLIKELY(nullptr == ptr)) {
+      state.SkipWithError("Calloc failed to calloc");
     }
     std::free(ptr);
     benchmark::DoNotOptimize(ptr);
@@ -99,9 +117,9 @@ BENCHMARK_DEFINE_F(PerformanceTestFixture, benchmark_on_realloc)(
   }
 }
 
-// Malloc sizes Range from 1 to 2^27 each time multiplying by 16. Each value tested
+// allocation sizes Range from 1 to 2^27 each time multiplying by 16. Each value tested
 // with/without performance metrics
-static void malloc_args(benchmark::internal::Benchmark * b)
+static void alloc_args(benchmark::internal::Benchmark * b)
 {
   for (int64_t shift_left = 0; shift_left < 32; shift_left += 4) {
     b->Args({kDisablePerformanceTracking, 1ll << shift_left});
@@ -110,7 +128,10 @@ static void malloc_args(benchmark::internal::Benchmark * b)
 }
 
 BENCHMARK_REGISTER_F(PerformanceTestFixture, benchmark_on_malloc)
-->ArgNames({"Enable Performance Tracking", "Malloc Size"})->Apply(malloc_args);
+->ArgNames({"Enable Performance Tracking", "Alloc Size"})->Apply(alloc_args);
+
+BENCHMARK_REGISTER_F(PerformanceTestFixture, benchmark_on_calloc)
+->ArgNames({"Enable Performance Tracking", "Alloc Size"})->Apply(alloc_args);
 
 // Three types of realloc tests, one where malloc is smaller than realloc, one where they are
 // the same, and one where malloc is larger than realloc. Realloc size ranges from 1 to 2^27
@@ -130,5 +151,5 @@ static void realloc_args(benchmark::internal::Benchmark * b)
 }
 
 BENCHMARK_REGISTER_F(PerformanceTestFixture, benchmark_on_realloc)
-->ArgNames({"Enable Performance Tracking", "Malloc Size", "Realloc Size"})
+->ArgNames({"Enable Performance Tracking", "Alloc Size", "Realloc Size"})
 ->Apply(realloc_args);

--- a/test/benchmark/benchmark_malloc_realloc_no_memory_tools.cpp
+++ b/test/benchmark/benchmark_malloc_realloc_no_memory_tools.cpp
@@ -22,14 +22,31 @@
 // benchmarks. However, they should allow for comparisons to the other benchmark_malloc_realloc
 static void benchmark_on_malloc(benchmark::State & state)
 {
-  const size_t malloc_size = state.range(0);
-  if (malloc_size < 1) {
+  const size_t alloc_size = state.range(0);
+  if (alloc_size < 1) {
     state.SkipWithError("Size for allocation is too small for this test");
   }
   for (auto _ : state) {
-    void * ptr = std::malloc(malloc_size);
+    void * ptr = std::malloc(alloc_size);
     if (PERFORMANCE_TEST_FIXTURE_UNLIKELY(nullptr == ptr)) {
       state.SkipWithError("Malloc failed to malloc");
+    }
+    std::free(ptr);
+    benchmark::DoNotOptimize(ptr);
+    benchmark::ClobberMemory();
+  }
+}
+
+static void benchmark_on_calloc(benchmark::State & state)
+{
+  const size_t alloc_size = state.range(0);
+  if (alloc_size < 1) {
+    state.SkipWithError("Size for allocation is too small for this test");
+  }
+  for (auto _ : state) {
+    void * ptr = std::calloc(1, alloc_size);
+    if (PERFORMANCE_TEST_FIXTURE_UNLIKELY(nullptr == ptr)) {
+      state.SkipWithError("Calloc failed to calloc");
     }
     std::free(ptr);
     benchmark::DoNotOptimize(ptr);
@@ -64,7 +81,9 @@ static void benchmark_on_realloc(benchmark::State & state)
 }
 
 // Malloc sizes Range from 1 to 2^27 each time multiplying by 16
-BENCHMARK(benchmark_on_malloc)->ArgNames({"Malloc Size"})->RangeMultiplier(16)->Range(1, 1 << 28);
+BENCHMARK(benchmark_on_malloc)->ArgNames({"Alloc Size"})->RangeMultiplier(16)->Range(1, 1 << 28);
+
+BENCHMARK(benchmark_on_calloc)->ArgNames({"Alloc Size"})->RangeMultiplier(16)->Range(1, 1 << 28);
 
 // Three types of realloc tests, one where malloc is smaller than realloc, one where they are
 // the same, and one where malloc is larger than realloc. Realloc size ranges from 1 to 2^27
@@ -81,4 +100,4 @@ static void realloc_args(benchmark::internal::Benchmark * b)
     }
   }
 }
-BENCHMARK(benchmark_on_realloc)->ArgNames({"Malloc Size", "Realloc Size"})->Apply(realloc_args);
+BENCHMARK(benchmark_on_realloc)->ArgNames({"Alloc Size", "Realloc Size"})->Apply(realloc_args);


### PR DESCRIPTION
Looks like we're completely missing calls to calloc in the memory metrics right now. This change condenses the callbacks and updates the tests as well as registering for calloc events.