### PR TITLE
Add "cstring" to the list of includes.

### DIFF
--- a/src/performance_test_fixture.cpp
+++ b/src/performance_test_fixture.cpp
@@ -16,6 +16,7 @@
 
 #include <algorithm>
 #include <cstdlib>
+#include <cstring>
 #include <vector>
 
 #ifdef _WIN32


### PR DESCRIPTION
Needed because this file uses strcmp().

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Fixes #18 