### PR TITLE
Resolve use-after-free compiler warnings

### DIFF
--- a/test/benchmark/benchmark_malloc_realloc.cpp
+++ b/test/benchmark/benchmark_malloc_realloc.cpp
@@ -108,11 +108,12 @@ BENCHMARK_DEFINE_F(PerformanceTestFixture, benchmark_on_realloc)(
     }
     void * realloc_ptr = std::realloc(ptr, realloc_size);
     if (PERFORMANCE_TEST_FIXTURE_UNLIKELY(nullptr == realloc_ptr)) {
-      std::free(ptr);
       state.SkipWithError("Malloc failed to realloc");
+    } else {
+      ptr = realloc_ptr;
     }
-    std::free(realloc_ptr);
-    benchmark::DoNotOptimize(realloc_ptr);
+    std::free(ptr);
+    benchmark::DoNotOptimize(ptr);
     benchmark::ClobberMemory();
   }
 }

--- a/test/benchmark/benchmark_malloc_realloc_no_memory_tools.cpp
+++ b/test/benchmark/benchmark_malloc_realloc_no_memory_tools.cpp
@@ -71,11 +71,12 @@ static void benchmark_on_realloc(benchmark::State & state)
     }
     void * realloc_ptr = std::realloc(ptr, realloc_size);
     if (PERFORMANCE_TEST_FIXTURE_UNLIKELY(nullptr == realloc_ptr)) {
-      std::free(ptr);
       state.SkipWithError("Malloc failed to realloc");
+    } else {
+      ptr = realloc_ptr;
     }
-    std::free(realloc_ptr);
-    benchmark::DoNotOptimize(realloc_ptr);
+    std::free(ptr);
+    benchmark::DoNotOptimize(ptr);
     benchmark::ClobberMemory();
   }
 }


### PR DESCRIPTION
This should resolve the following warnings, which I'm seeing on Fedora 37's gcc 12.2.1:
```
src/ros2/performance_test_fixture/test/benchmark/benchmark_malloc_realloc_no_memory_tools.cpp: In function ‘void benchmark_on_realloc(benchmark::State&)’:
src/ros2/performance_test_fixture/test/benchmark/benchmark_malloc_realloc_no_memory_tools.cpp:74:16: warning: pointer ‘ptr’ may be used after ‘void* realloc(void*, size_t)’ [-Wuse-after-free]
   74 |       std::free(ptr);
      |       ~~~~~~~~~^~~~~
src/ros2/performance_test_fixture/test/benchmark/benchmark_malloc_realloc_no_memory_tools.cpp:72:38: note: call to ‘void* realloc(void*, size_t)’ here
   72 |     void * realloc_ptr = std::realloc(ptr, realloc_size);
      |                          ~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~
src/ros2/performance_test_fixture/test/benchmark/benchmark_malloc_realloc.cpp: In member function ‘virtual void PerformanceTestFixture_benchmark_on_realloc_Benchmark::BenchmarkCase(benchmark::State&)’:
src/ros2/performance_test_fixture/test/benchmark/benchmark_malloc_realloc.cpp:111:16: warning: pointer ‘ptr’ may be used after ‘void* realloc(void*, size_t)’ [-Wuse-after-free]
  111 |       std::free(ptr);
      |       ~~~~~~~~~^~~~~
src/ros2/performance_test_fixture/test/benchmark/benchmark_malloc_realloc.cpp:109:38: note: call to ‘void* realloc(void*, size_t)’ here
  109 |     void * realloc_ptr = std::realloc(ptr, realloc_size);
      |                          ~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~

```