### PR TITLE
Fix a warning when building on Ubuntu Noble.

### DIFF
--- a/test/benchmark/benchmark_malloc_realloc.cpp
+++ b/test/benchmark/benchmark_malloc_realloc.cpp
@@ -66,8 +66,8 @@ BENCHMARK_DEFINE_F(PerformanceTestFixture, benchmark_on_malloc)(
     if (PERFORMANCE_TEST_FIXTURE_UNLIKELY(nullptr == ptr)) {
       state.SkipWithError("Malloc failed to malloc");
     }
-    std::free(ptr);
     benchmark::DoNotOptimize(ptr);
+    std::free(ptr);
     benchmark::ClobberMemory();
   }
 }
@@ -84,8 +84,8 @@ BENCHMARK_DEFINE_F(PerformanceTestFixture, benchmark_on_calloc)(
     if (PERFORMANCE_TEST_FIXTURE_UNLIKELY(nullptr == ptr)) {
       state.SkipWithError("Calloc failed to calloc");
     }
-    std::free(ptr);
     benchmark::DoNotOptimize(ptr);
+    std::free(ptr);
     benchmark::ClobberMemory();
   }
 }
@@ -112,8 +112,8 @@ BENCHMARK_DEFINE_F(PerformanceTestFixture, benchmark_on_realloc)(
     } else {
       ptr = realloc_ptr;
     }
-    std::free(ptr);
     benchmark::DoNotOptimize(ptr);
+    std::free(ptr);
     benchmark::ClobberMemory();
   }
 }

--- a/test/benchmark/benchmark_malloc_realloc_no_memory_tools.cpp
+++ b/test/benchmark/benchmark_malloc_realloc_no_memory_tools.cpp
@@ -31,8 +31,8 @@ static void benchmark_on_malloc(benchmark::State & state)
     if (PERFORMANCE_TEST_FIXTURE_UNLIKELY(nullptr == ptr)) {
       state.SkipWithError("Malloc failed to malloc");
     }
-    std::free(ptr);
     benchmark::DoNotOptimize(ptr);
+    std::free(ptr);
     benchmark::ClobberMemory();
   }
 }
@@ -48,8 +48,8 @@ static void benchmark_on_calloc(benchmark::State & state)
     if (PERFORMANCE_TEST_FIXTURE_UNLIKELY(nullptr == ptr)) {
       state.SkipWithError("Calloc failed to calloc");
     }
-    std::free(ptr);
     benchmark::DoNotOptimize(ptr);
+    std::free(ptr);
     benchmark::ClobberMemory();
   }
 }
@@ -75,8 +75,8 @@ static void benchmark_on_realloc(benchmark::State & state)
     } else {
       ptr = realloc_ptr;
     }
-    std::free(ptr);
     benchmark::DoNotOptimize(ptr);
+    std::free(ptr);
     benchmark::ClobberMemory();
   }
 }


### PR DESCRIPTION
In particular, gcc 13.2 was complaining that we were accessing a pointer after a free.  And that was technically true; the calls to DoNotOptimize(ptr) were after the free.  Just move this before the free (when the ptr is still valid) to remove the warning, but still ensure that we don't optimize the pointer away.