### PR TITLE
Fix deprecated benchmark::internal::Benchmark warnings in performance tests

### DIFF
--- a/test/benchmark/benchmark_malloc_realloc.cpp
+++ b/test/benchmark/benchmark_malloc_realloc.cpp
@@ -120,7 +120,7 @@ BENCHMARK_DEFINE_F(PerformanceTestFixture, benchmark_on_realloc)(
 
 // allocation sizes Range from 1 to 2^27 each time multiplying by 16. Each value tested
 // with/without performance metrics
-static void alloc_args(benchmark::internal::Benchmark * b)
+static void alloc_args(benchmark::Benchmark * b)
 {
   for (int64_t shift_left = 0; shift_left < 32; shift_left += 4) {
     b->Args({kDisablePerformanceTracking, 1ll << shift_left});
@@ -137,7 +137,7 @@ BENCHMARK_REGISTER_F(PerformanceTestFixture, benchmark_on_calloc)
 // Three types of realloc tests, one where malloc is smaller than realloc, one where they are
 // the same, and one where malloc is larger than realloc. Realloc size ranges from 1 to 2^27
 // each time multiplying by 32. Each stop is tested with/without performance metrics
-static void realloc_args(benchmark::internal::Benchmark * b)
+static void realloc_args(benchmark::Benchmark * b)
 {
   for (int64_t malloc_adjustment = -1; malloc_adjustment <= 1; ++malloc_adjustment) {
     for (int64_t realloc_shift = 0; realloc_shift < 32; realloc_shift += 8) {

--- a/test/benchmark/benchmark_malloc_realloc.cpp
+++ b/test/benchmark/benchmark_malloc_realloc.cpp
@@ -138,7 +138,7 @@ BENCHMARK_REGISTER_F(PerformanceTestFixture, benchmark_on_calloc)
 // Three types of realloc tests, one where malloc is smaller than realloc, one where they are
 // the same, and one where malloc is larger than realloc. Realloc size ranges from 1 to 2^27
 // each time multiplying by 32. Each stop is tested with/without performance metrics
-const auto alloc_args = [](auto * b)
+const auto realloc_args = [](auto * b)
 {
   for (int64_t malloc_adjustment = -1; malloc_adjustment <= 1; ++malloc_adjustment) {
     for (int64_t realloc_shift = 0; realloc_shift < 32; realloc_shift += 8) {

--- a/test/benchmark/benchmark_malloc_realloc.cpp
+++ b/test/benchmark/benchmark_malloc_realloc.cpp
@@ -18,18 +18,6 @@
 #include "./macros.h"
 #include "performance_test_fixture/performance_test_fixture.hpp"
 
-namespace benchmark_compat
-{
-
-#if defined(BENCHMARK_VERSION_MAJOR) && \
-  ((BENCHMARK_VERSION_MAJOR > 1) || \
-  (BENCHMARK_VERSION_MAJOR == 1 && BENCHMARK_VERSION_MINOR >= 9))
-using ApplyBenchmark = benchmark::Benchmark;
-#else
-using ApplyBenchmark = benchmark::internal::Benchmark;
-#endif
-
-}  // namespace benchmark_compat
 
 namespace
 {
@@ -133,13 +121,13 @@ BENCHMARK_DEFINE_F(PerformanceTestFixture, benchmark_on_realloc)(
 
 // allocation sizes Range from 1 to 2^27 each time multiplying by 16. Each value tested
 // with/without performance metrics
-static void alloc_args(benchmark_compat::ApplyBenchmark * b)
+const auto alloc_args = [](auto * b)
 {
   for (int64_t shift_left = 0; shift_left < 32; shift_left += 4) {
     b->Args({kDisablePerformanceTracking, 1ll << shift_left});
     b->Args({kEnablePerformanceTracking, 1ll << shift_left});
   }
-}
+};
 
 BENCHMARK_REGISTER_F(PerformanceTestFixture, benchmark_on_malloc)
 ->ArgNames({"Enable Performance Tracking", "Alloc Size"})->Apply(alloc_args);
@@ -150,7 +138,7 @@ BENCHMARK_REGISTER_F(PerformanceTestFixture, benchmark_on_calloc)
 // Three types of realloc tests, one where malloc is smaller than realloc, one where they are
 // the same, and one where malloc is larger than realloc. Realloc size ranges from 1 to 2^27
 // each time multiplying by 32. Each stop is tested with/without performance metrics
-static void realloc_args(benchmark_compat::ApplyBenchmark * b)
+const auto alloc_args = [](auto * b)
 {
   for (int64_t malloc_adjustment = -1; malloc_adjustment <= 1; ++malloc_adjustment) {
     for (int64_t realloc_shift = 0; realloc_shift < 32; realloc_shift += 8) {
@@ -162,7 +150,7 @@ static void realloc_args(benchmark_compat::ApplyBenchmark * b)
       b->Args({kEnablePerformanceTracking, 1ll << malloc_shift, 1ll << realloc_shift});
     }
   }
-}
+};
 
 BENCHMARK_REGISTER_F(PerformanceTestFixture, benchmark_on_realloc)
 ->ArgNames({"Enable Performance Tracking", "Alloc Size", "Realloc Size"})

--- a/test/benchmark/benchmark_malloc_realloc.cpp
+++ b/test/benchmark/benchmark_malloc_realloc.cpp
@@ -18,7 +18,6 @@
 #include "./macros.h"
 #include "performance_test_fixture/performance_test_fixture.hpp"
 
-
 namespace
 {
 
@@ -122,12 +121,12 @@ BENCHMARK_DEFINE_F(PerformanceTestFixture, benchmark_on_realloc)(
 // allocation sizes Range from 1 to 2^27 each time multiplying by 16. Each value tested
 // with/without performance metrics
 const auto alloc_args = [](auto * b)
-{
-  for (int64_t shift_left = 0; shift_left < 32; shift_left += 4) {
-    b->Args({kDisablePerformanceTracking, 1ll << shift_left});
-    b->Args({kEnablePerformanceTracking, 1ll << shift_left});
-  }
-};
+  {
+    for (int64_t shift_left = 0; shift_left < 32; shift_left += 4) {
+      b->Args({kDisablePerformanceTracking, 1ll << shift_left});
+      b->Args({kEnablePerformanceTracking, 1ll << shift_left});
+    }
+  };
 
 BENCHMARK_REGISTER_F(PerformanceTestFixture, benchmark_on_malloc)
 ->ArgNames({"Enable Performance Tracking", "Alloc Size"})->Apply(alloc_args);
@@ -139,18 +138,18 @@ BENCHMARK_REGISTER_F(PerformanceTestFixture, benchmark_on_calloc)
 // the same, and one where malloc is larger than realloc. Realloc size ranges from 1 to 2^27
 // each time multiplying by 32. Each stop is tested with/without performance metrics
 const auto realloc_args = [](auto * b)
-{
-  for (int64_t malloc_adjustment = -1; malloc_adjustment <= 1; ++malloc_adjustment) {
-    for (int64_t realloc_shift = 0; realloc_shift < 32; realloc_shift += 8) {
-      const int64_t malloc_shift = realloc_shift + malloc_adjustment;
-      if (malloc_shift < 0) {
-        continue;
+  {
+    for (int64_t malloc_adjustment = -1; malloc_adjustment <= 1; ++malloc_adjustment) {
+      for (int64_t realloc_shift = 0; realloc_shift < 32; realloc_shift += 8) {
+        const int64_t malloc_shift = realloc_shift + malloc_adjustment;
+        if (malloc_shift < 0) {
+          continue;
+        }
+        b->Args({kDisablePerformanceTracking, 1ll << malloc_shift, 1ll << realloc_shift});
+        b->Args({kEnablePerformanceTracking, 1ll << malloc_shift, 1ll << realloc_shift});
       }
-      b->Args({kDisablePerformanceTracking, 1ll << malloc_shift, 1ll << realloc_shift});
-      b->Args({kEnablePerformanceTracking, 1ll << malloc_shift, 1ll << realloc_shift});
     }
-  }
-};
+  };
 
 BENCHMARK_REGISTER_F(PerformanceTestFixture, benchmark_on_realloc)
 ->ArgNames({"Enable Performance Tracking", "Alloc Size", "Realloc Size"})

--- a/test/benchmark/benchmark_malloc_realloc.cpp
+++ b/test/benchmark/benchmark_malloc_realloc.cpp
@@ -18,6 +18,19 @@
 #include "./macros.h"
 #include "performance_test_fixture/performance_test_fixture.hpp"
 
+namespace benchmark_compat
+{
+
+#if defined(BENCHMARK_VERSION_MAJOR) && \
+  ((BENCHMARK_VERSION_MAJOR > 1) || \
+  (BENCHMARK_VERSION_MAJOR == 1 && BENCHMARK_VERSION_MINOR >= 9))
+using ApplyBenchmark = benchmark::Benchmark;
+#else
+using ApplyBenchmark = benchmark::internal::Benchmark;
+#endif
+
+}  // namespace benchmark_compat
+
 namespace
 {
 
@@ -120,7 +133,7 @@ BENCHMARK_DEFINE_F(PerformanceTestFixture, benchmark_on_realloc)(
 
 // allocation sizes Range from 1 to 2^27 each time multiplying by 16. Each value tested
 // with/without performance metrics
-static void alloc_args(benchmark::Benchmark * b)
+static void alloc_args(benchmark_compat::ApplyBenchmark * b)
 {
   for (int64_t shift_left = 0; shift_left < 32; shift_left += 4) {
     b->Args({kDisablePerformanceTracking, 1ll << shift_left});
@@ -137,7 +150,7 @@ BENCHMARK_REGISTER_F(PerformanceTestFixture, benchmark_on_calloc)
 // Three types of realloc tests, one where malloc is smaller than realloc, one where they are
 // the same, and one where malloc is larger than realloc. Realloc size ranges from 1 to 2^27
 // each time multiplying by 32. Each stop is tested with/without performance metrics
-static void realloc_args(benchmark::Benchmark * b)
+static void realloc_args(benchmark_compat::ApplyBenchmark * b)
 {
   for (int64_t malloc_adjustment = -1; malloc_adjustment <= 1; ++malloc_adjustment) {
     for (int64_t realloc_shift = 0; realloc_shift < 32; realloc_shift += 8) {

--- a/test/benchmark/benchmark_malloc_realloc_no_memory_tools.cpp
+++ b/test/benchmark/benchmark_malloc_realloc_no_memory_tools.cpp
@@ -89,7 +89,7 @@ BENCHMARK(benchmark_on_calloc)->ArgNames({"Alloc Size"})->RangeMultiplier(16)->R
 // Three types of realloc tests, one where malloc is smaller than realloc, one where they are
 // the same, and one where malloc is larger than realloc. Realloc size ranges from 1 to 2^27
 // each time multiplying by 32.
-static void realloc_args(benchmark::internal::Benchmark * b)
+static void realloc_args(benchmark::Benchmark * b)
 {
   for (int64_t malloc_adjustment = -1; malloc_adjustment <= 1; ++malloc_adjustment) {
     for (int64_t realloc_shift = 0; realloc_shift < 32; realloc_shift += 8) {

--- a/test/benchmark/benchmark_malloc_realloc_no_memory_tools.cpp
+++ b/test/benchmark/benchmark_malloc_realloc_no_memory_tools.cpp
@@ -18,19 +18,6 @@
 
 #include "./macros.h"
 
-namespace benchmark_compat
-{
-
-#if defined(BENCHMARK_VERSION_MAJOR) && \
-  ((BENCHMARK_VERSION_MAJOR > 1) || \
-  (BENCHMARK_VERSION_MAJOR == 1 && BENCHMARK_VERSION_MINOR >= 9))
-using ApplyBenchmark = benchmark::Benchmark;
-#else
-using ApplyBenchmark = benchmark::internal::Benchmark;
-#endif
-
-}  // namespace benchmark_compat
-
 // This does not make use of PauseTiming or ResumeTiming because timing is very short for these
 // benchmarks. However, they should allow for comparisons to the other benchmark_malloc_realloc
 static void benchmark_on_malloc(benchmark::State & state)
@@ -102,7 +89,7 @@ BENCHMARK(benchmark_on_calloc)->ArgNames({"Alloc Size"})->RangeMultiplier(16)->R
 // Three types of realloc tests, one where malloc is smaller than realloc, one where they are
 // the same, and one where malloc is larger than realloc. Realloc size ranges from 1 to 2^27
 // each time multiplying by 32.
-static void realloc_args(benchmark_compat::ApplyBenchmark * b)
+const auto alloc_args = [](auto * b)
 {
   for (int64_t malloc_adjustment = -1; malloc_adjustment <= 1; ++malloc_adjustment) {
     for (int64_t realloc_shift = 0; realloc_shift < 32; realloc_shift += 8) {
@@ -113,5 +100,5 @@ static void realloc_args(benchmark_compat::ApplyBenchmark * b)
       b->Args({1ll << malloc_shift, 1ll << realloc_shift});
     }
   }
-}
+};
 BENCHMARK(benchmark_on_realloc)->ArgNames({"Alloc Size", "Realloc Size"})->Apply(realloc_args);

--- a/test/benchmark/benchmark_malloc_realloc_no_memory_tools.cpp
+++ b/test/benchmark/benchmark_malloc_realloc_no_memory_tools.cpp
@@ -89,7 +89,7 @@ BENCHMARK(benchmark_on_calloc)->ArgNames({"Alloc Size"})->RangeMultiplier(16)->R
 // Three types of realloc tests, one where malloc is smaller than realloc, one where they are
 // the same, and one where malloc is larger than realloc. Realloc size ranges from 1 to 2^27
 // each time multiplying by 32.
-const auto alloc_args = [](auto * b)
+const auto realloc_args = [](auto * b)
 {
   for (int64_t malloc_adjustment = -1; malloc_adjustment <= 1; ++malloc_adjustment) {
     for (int64_t realloc_shift = 0; realloc_shift < 32; realloc_shift += 8) {

--- a/test/benchmark/benchmark_malloc_realloc_no_memory_tools.cpp
+++ b/test/benchmark/benchmark_malloc_realloc_no_memory_tools.cpp
@@ -90,15 +90,15 @@ BENCHMARK(benchmark_on_calloc)->ArgNames({"Alloc Size"})->RangeMultiplier(16)->R
 // the same, and one where malloc is larger than realloc. Realloc size ranges from 1 to 2^27
 // each time multiplying by 32.
 const auto realloc_args = [](auto * b)
-{
-  for (int64_t malloc_adjustment = -1; malloc_adjustment <= 1; ++malloc_adjustment) {
-    for (int64_t realloc_shift = 0; realloc_shift < 32; realloc_shift += 8) {
-      const int64_t malloc_shift = realloc_shift + malloc_adjustment;
-      if (malloc_shift < 0) {
-        continue;
+  {
+    for (int64_t malloc_adjustment = -1; malloc_adjustment <= 1; ++malloc_adjustment) {
+      for (int64_t realloc_shift = 0; realloc_shift < 32; realloc_shift += 8) {
+        const int64_t malloc_shift = realloc_shift + malloc_adjustment;
+        if (malloc_shift < 0) {
+          continue;
+        }
+        b->Args({1ll << malloc_shift, 1ll << realloc_shift});
       }
-      b->Args({1ll << malloc_shift, 1ll << realloc_shift});
     }
-  }
-};
+  };
 BENCHMARK(benchmark_on_realloc)->ArgNames({"Alloc Size", "Realloc Size"})->Apply(realloc_args);

--- a/test/benchmark/benchmark_malloc_realloc_no_memory_tools.cpp
+++ b/test/benchmark/benchmark_malloc_realloc_no_memory_tools.cpp
@@ -18,6 +18,19 @@
 
 #include "./macros.h"
 
+namespace benchmark_compat
+{
+
+#if defined(BENCHMARK_VERSION_MAJOR) && \
+  ((BENCHMARK_VERSION_MAJOR > 1) || \
+  (BENCHMARK_VERSION_MAJOR == 1 && BENCHMARK_VERSION_MINOR >= 9))
+using ApplyBenchmark = benchmark::Benchmark;
+#else
+using ApplyBenchmark = benchmark::internal::Benchmark;
+#endif
+
+}  // namespace benchmark_compat
+
 // This does not make use of PauseTiming or ResumeTiming because timing is very short for these
 // benchmarks. However, they should allow for comparisons to the other benchmark_malloc_realloc
 static void benchmark_on_malloc(benchmark::State & state)
@@ -89,7 +102,7 @@ BENCHMARK(benchmark_on_calloc)->ArgNames({"Alloc Size"})->RangeMultiplier(16)->R
 // Three types of realloc tests, one where malloc is smaller than realloc, one where they are
 // the same, and one where malloc is larger than realloc. Realloc size ranges from 1 to 2^27
 // each time multiplying by 32.
-static void realloc_args(benchmark::Benchmark * b)
+static void realloc_args(benchmark_compat::ApplyBenchmark * b)
 {
   for (int64_t malloc_adjustment = -1; malloc_adjustment <= 1; ++malloc_adjustment) {
     for (int64_t realloc_shift = 0; realloc_shift < 32; realloc_shift += 8) {


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes #33 

### Is this user-facing behavior change?

No

### Did you use Generative AI?

No

### Additional Information

As the issue says, new version of Google bechmark updated call from `benchmark::internal::Benchmark` to `benchmark::Benchmark`
