### PR TITLE
Avoid deprecations, use benchmark::Benchmark when available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,17 @@ find_package(ament_cmake_test REQUIRED)
 find_package(benchmark REQUIRED)
 find_package(osrf_testing_tools_cpp REQUIRED)
 
+include(CheckCXXSourceCompiles)
+set(CMAKE_REQUIRED_LIBRARIES benchmark::benchmark)
+check_cxx_source_compiles("
+#include <benchmark/benchmark.h>
+void test(benchmark::Benchmark * b) { (void)b; }
+int main() { return 0; }
+" HAVE_BENCHMARK_BENCHMARK)
+if(HAVE_BENCHMARK_BENCHMARK)
+  add_compile_definitions(HAVE_BENCHMARK_BENCHMARK)
+endif()
+
 add_library(${PROJECT_NAME}
   src/${PROJECT_NAME}.cpp)
 

--- a/test/benchmark/benchmark_malloc_realloc.cpp
+++ b/test/benchmark/benchmark_malloc_realloc.cpp
@@ -21,6 +21,12 @@
 namespace
 {
 
+#ifdef HAVE_BENCHMARK_BENCHMARK
+using BenchmarkType = benchmark::Benchmark;
+#else
+using BenchmarkType = benchmark::internal::Benchmark;
+#endif
+
 constexpr int kEnablePerformanceTracking = 1;
 constexpr int kDisablePerformanceTracking = 0;
 
@@ -120,7 +126,7 @@ BENCHMARK_DEFINE_F(PerformanceTestFixture, benchmark_on_realloc)(
 
 // allocation sizes Range from 1 to 2^27 each time multiplying by 16. Each value tested
 // with/without performance metrics
-static void alloc_args(benchmark::internal::Benchmark * b)
+static void alloc_args(BenchmarkType * b)
 {
   for (int64_t shift_left = 0; shift_left < 32; shift_left += 4) {
     b->Args({kDisablePerformanceTracking, 1ll << shift_left});
@@ -137,7 +143,7 @@ BENCHMARK_REGISTER_F(PerformanceTestFixture, benchmark_on_calloc)
 // Three types of realloc tests, one where malloc is smaller than realloc, one where they are
 // the same, and one where malloc is larger than realloc. Realloc size ranges from 1 to 2^27
 // each time multiplying by 32. Each stop is tested with/without performance metrics
-static void realloc_args(benchmark::internal::Benchmark * b)
+static void realloc_args(BenchmarkType * b)
 {
   for (int64_t malloc_adjustment = -1; malloc_adjustment <= 1; ++malloc_adjustment) {
     for (int64_t realloc_shift = 0; realloc_shift < 32; realloc_shift += 8) {

--- a/test/benchmark/benchmark_malloc_realloc_no_memory_tools.cpp
+++ b/test/benchmark/benchmark_malloc_realloc_no_memory_tools.cpp
@@ -18,6 +18,12 @@
 
 #include "./macros.h"
 
+#ifdef HAVE_BENCHMARK_BENCHMARK
+using BenchmarkType = benchmark::Benchmark;
+#else
+using BenchmarkType = benchmark::internal::Benchmark;
+#endif
+
 // This does not make use of PauseTiming or ResumeTiming because timing is very short for these
 // benchmarks. However, they should allow for comparisons to the other benchmark_malloc_realloc
 static void benchmark_on_malloc(benchmark::State & state)
@@ -89,7 +95,7 @@ BENCHMARK(benchmark_on_calloc)->ArgNames({"Alloc Size"})->RangeMultiplier(16)->R
 // Three types of realloc tests, one where malloc is smaller than realloc, one where they are
 // the same, and one where malloc is larger than realloc. Realloc size ranges from 1 to 2^27
 // each time multiplying by 32.
-static void realloc_args(benchmark::internal::Benchmark * b)
+static void realloc_args(BenchmarkType * b)
 {
   for (int64_t malloc_adjustment = -1; malloc_adjustment <= 1; ++malloc_adjustment) {
     for (int64_t realloc_shift = 0; realloc_shift < 32; realloc_shift += 8) {


### PR DESCRIPTION
## Description

This impacts RHEL 10 where this warning appears. I can't get a clear read on which versions of benchmark use one symbol or the other, so I chose not to use a version gate here.

Fixes https://github.com/ros2/performance_test_fixture/issues/33

### Is this user-facing behavior change?

### Did you use Generative AI?

I guess I used AI to generate candidate bugs/warnings to fix.

Assisted-by: Gemini-CLI

### Additional Information

